### PR TITLE
Fix to initial setup command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ You are now ready to use LaravelGPT!
 ### Publishing the Config File
 You can publish the config file with:
 ```bash
-php artisan vendor:publish --provider="MalteKuhr\LaravelGPT\Providers\GPTServiceProvider" --tag="config"
+php artisan vendor:publish --provider="MalteKuhr\LaravelGPT\Providers\GPTServiceProvider" --tag="public"
 ```
 
 The published config file is located at `config/laravel-gpt.php`.


### PR DESCRIPTION
## Bug

<img width="1524" alt="Screenshot 2024-01-21 at 12 06 45 PM" src="https://github.com/maltekuhr/laravel-gpt-docs/assets/32709073/8ad6ed3d-d25d-4420-986f-f514d5aece59">

## Caused by: 

<img width="938" alt="Screenshot 2024-01-21 at 12 07 03 PM" src="https://github.com/maltekuhr/laravel-gpt-docs/assets/32709073/15c22dcf-143c-44f2-89fd-840958bea3e5">

## Fixed: 
<img width="1530" alt="Screenshot 2024-01-21 at 12 06 49 PM" src="https://github.com/maltekuhr/laravel-gpt-docs/assets/32709073/5d5a0481-5a7f-44d0-9920-8c5ce021acc2">

Or change the GPTServiceProvider public command group 🤷.

> Super cool project man!